### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RS3 is a interface to S3 using libs3.  Using RS3 you can do many tasks including
 ## Installing on Linux ##
 Make sure that `libxml2-dev` and `libcurl3-dev` is installed
 
-In R, install devtools and run `install_github.com("RS3", "Gastrograph")`
+In R, install devtools and run `install_github("Gastrograph/RS3")`
 
 
 ## Installing in Windows ##


### PR DESCRIPTION
install_github username parameter is deprecated. Updated install command to use a single parameter instead.