### PR TITLE
Suggestion for making RS3 compile on Mac OSX

### DIFF
--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -73,6 +73,10 @@ else
         QUIET_ECHO = @ echo
 endif
 
+SONAME = -soname
+ifeq ($(shell uname -s),Darwin)
+	SONAME = -install_name
+endif
 
 # --------------------------------------------------------------------------
 # BUILD directory

--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -162,7 +162,7 @@ exported: libs3 headers
 install: exported
 	$(QUIET_ECHO) \
         $(DESTDIR)/lib/libs3.so.$(LIBS3_VER): Installing shared library
-	$(VERBOSE_SHOW) install -d -m u+rw,go+r \
+	$(VERBOSE_SHOW) install -m u+rw,go+r \
                $(BUILD)/lib/libs3.so.$(LIBS3_VER_MAJOR) \
                $(DESTDIR)/lib/libs3.so.$(LIBS3_VER)
 	$(QUIET_ECHO) \
@@ -172,10 +172,10 @@ install: exported
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.so: Linking shared library
 	$(VERBOSE_SHOW) ln -sf libs3.so.$(LIBS3_VER_MAJOR) $(DESTDIR)/lib/libs3.so
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.a: Installing static library
-	$(VERBOSE_SHOW) install -d -m u+rw,go+r $(BUILD)/lib/libs3.a \
+	$(VERBOSE_SHOW) install -m u+rw,go+r $(BUILD)/lib/libs3.a \
                     $(DESTDIR)/lib/libs3.a
 	$(QUIET_ECHO) $(DESTDIR)/include/libs3.h: Installing header
-	$(VERBOSE_SHOW) install -d -m u+rw,go+r $(BUILD)/include/libs3.h \
+	$(VERBOSE_SHOW) install -m u+rw,go+r $(BUILD)/include/libs3.h \
                     $(DESTDIR)/include/libs3.h
 
 

--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -230,7 +230,7 @@ LIBS3_SOURCES := acl.c bucket.c error_parser.c general.c \
 $(LIBS3_SHARED): $(LIBS3_SOURCES:%.c=$(BUILD)/obj/%.do)
 	$(QUIET_ECHO) $@: Building shared library
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc -shared -Wl,-soname,libs3.so.$(LIBS3_VER_MAJOR) \
+	$(VERBOSE_SHOW) gcc -shared -Wl,-install_name,libs3.so.$(LIBS3_VER_MAJOR) \
         -o $@ $^ $(LDFLAGS)
 
 $(LIBS3_STATIC): $(LIBS3_SOURCES:%.c=$(BUILD)/obj/%.o)

--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -162,7 +162,7 @@ exported: libs3 headers
 install: exported
 	$(QUIET_ECHO) \
         $(DESTDIR)/lib/libs3.so.$(LIBS3_VER): Installing shared library
-	$(VERBOSE_SHOW) install -Dps -m u+rw,go+r \
+	$(VERBOSE_SHOW) install -dps -m u+rw,go+r \
                $(BUILD)/lib/libs3.so.$(LIBS3_VER_MAJOR) \
                $(DESTDIR)/lib/libs3.so.$(LIBS3_VER)
 	$(QUIET_ECHO) \
@@ -172,10 +172,10 @@ install: exported
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.so: Linking shared library
 	$(VERBOSE_SHOW) ln -sf libs3.so.$(LIBS3_VER_MAJOR) $(DESTDIR)/lib/libs3.so
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.a: Installing static library
-	$(VERBOSE_SHOW) install -Dp -m u+rw,go+r $(BUILD)/lib/libs3.a \
+	$(VERBOSE_SHOW) install -dp -m u+rw,go+r $(BUILD)/lib/libs3.a \
                     $(DESTDIR)/lib/libs3.a
 	$(QUIET_ECHO) $(DESTDIR)/include/libs3.h: Installing header
-	$(VERBOSE_SHOW) install -Dp -m u+rw,go+r $(BUILD)/include/libs3.h \
+	$(VERBOSE_SHOW) install -dp -m u+rw,go+r $(BUILD)/include/libs3.h \
                     $(DESTDIR)/include/libs3.h
 
 

--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -162,7 +162,7 @@ exported: libs3 headers
 install: exported
 	$(QUIET_ECHO) \
         $(DESTDIR)/lib/libs3.so.$(LIBS3_VER): Installing shared library
-	$(VERBOSE_SHOW) install -dps -m u+rw,go+r \
+	$(VERBOSE_SHOW) install -Dps -m u+rw,go+r \
                $(BUILD)/lib/libs3.so.$(LIBS3_VER_MAJOR) \
                $(DESTDIR)/lib/libs3.so.$(LIBS3_VER)
 	$(QUIET_ECHO) \
@@ -172,10 +172,10 @@ install: exported
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.so: Linking shared library
 	$(VERBOSE_SHOW) ln -sf libs3.so.$(LIBS3_VER_MAJOR) $(DESTDIR)/lib/libs3.so
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.a: Installing static library
-	$(VERBOSE_SHOW) install -dp -m u+rw,go+r $(BUILD)/lib/libs3.a \
+	$(VERBOSE_SHOW) install -Dp -m u+rw,go+r $(BUILD)/lib/libs3.a \
                     $(DESTDIR)/lib/libs3.a
 	$(QUIET_ECHO) $(DESTDIR)/include/libs3.h: Installing header
-	$(VERBOSE_SHOW) install -dp -m u+rw,go+r $(BUILD)/include/libs3.h \
+	$(VERBOSE_SHOW) install -Dp -m u+rw,go+r $(BUILD)/include/libs3.h \
                     $(DESTDIR)/include/libs3.h
 
 

--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -162,7 +162,7 @@ exported: libs3 headers
 install: exported
 	$(QUIET_ECHO) \
         $(DESTDIR)/lib/libs3.so.$(LIBS3_VER): Installing shared library
-	$(VERBOSE_SHOW) install -Dps -m u+rw,go+r \
+	$(VERBOSE_SHOW) install -d -m u+rw,go+r \
                $(BUILD)/lib/libs3.so.$(LIBS3_VER_MAJOR) \
                $(DESTDIR)/lib/libs3.so.$(LIBS3_VER)
 	$(QUIET_ECHO) \
@@ -172,10 +172,10 @@ install: exported
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.so: Linking shared library
 	$(VERBOSE_SHOW) ln -sf libs3.so.$(LIBS3_VER_MAJOR) $(DESTDIR)/lib/libs3.so
 	$(QUIET_ECHO) $(DESTDIR)/lib/libs3.a: Installing static library
-	$(VERBOSE_SHOW) install -Dp -m u+rw,go+r $(BUILD)/lib/libs3.a \
+	$(VERBOSE_SHOW) install -d -m u+rw,go+r $(BUILD)/lib/libs3.a \
                     $(DESTDIR)/lib/libs3.a
 	$(QUIET_ECHO) $(DESTDIR)/include/libs3.h: Installing header
-	$(VERBOSE_SHOW) install -Dp -m u+rw,go+r $(BUILD)/include/libs3.h \
+	$(VERBOSE_SHOW) install -d -m u+rw,go+r $(BUILD)/include/libs3.h \
                     $(DESTDIR)/include/libs3.h
 
 

--- a/src/libs3/GNUmakefile
+++ b/src/libs3/GNUmakefile
@@ -230,7 +230,7 @@ LIBS3_SOURCES := acl.c bucket.c error_parser.c general.c \
 $(LIBS3_SHARED): $(LIBS3_SOURCES:%.c=$(BUILD)/obj/%.do)
 	$(QUIET_ECHO) $@: Building shared library
 	@ mkdir -p $(dir $@)
-	$(VERBOSE_SHOW) gcc -shared -Wl,-install_name,libs3.so.$(LIBS3_VER_MAJOR) \
+	$(VERBOSE_SHOW) gcc -shared -Wl, $(SONAME),libs3.so.$(LIBS3_VER_MAJOR) \
         -o $@ $^ $(LDFLAGS)
 
 $(LIBS3_STATIC): $(LIBS3_SOURCES:%.c=$(BUILD)/obj/%.o)

--- a/src/libs3/GNUmakefile.osx
+++ b/src/libs3/GNUmakefile.osx
@@ -73,6 +73,10 @@ else
         QUIET_ECHO = @ echo
 endif
 
+SONAME = -soname
+ifeq ($(shell uname -s),Darwin)
+	SONAME = -install_name
+endif
 
 # --------------------------------------------------------------------------
 # BUILD directory

--- a/src/libs3/inc/util.h
+++ b/src/libs3/inc/util.h
@@ -58,7 +58,7 @@
 // 255 is the maximum bucket length
 #define MAX_URI_SIZE \
     ((sizeof("https:///") - 1) + S3_MAX_HOSTNAME_SIZE + 255 + 1 +       \
-     MAX_URLENCODED_KEY_SIZE + (sizeof("?torrent" - 1)) + 1)
+     MAX_URLENCODED_KEY_SIZE + (sizeof("?torrent") - 1) + 1)
 
 // Maximum size of a canonicalized resource
 #define MAX_CANONICALIZED_RESOURCE_SIZE \


### PR DESCRIPTION
clang (default compiler on OSX) has problem with the following:
 `MAX_URLENCODED_KEY_SIZE + (sizeof("?torrent" - 1)) + 1)`

I changed that. The compiler has then problem with the install flag --D. I removed -Dps and -Dp flags do they serve any purpose? Compiles fine on Mac OSX after that.
